### PR TITLE
Fix discarding chunk of data when write ends exactly in the end of the buffer.

### DIFF
--- a/lfbb_cpp/inc/lfbb_impl.hpp
+++ b/lfbb_cpp/inc/lfbb_impl.hpp
@@ -88,17 +88,19 @@ void LfBb<T, size>::WriteRelease(const size_t written) {
         w = 0U;
     }
 
-    /* Increment the write index and wrap to 0 if needed */
+    // Increment the write index
     w += written;
-    if (w == size) {
-        w = 0U;
-    }
 
     /* If we wrote over invalidated parts of the buffer move the invalidate
      * index
      */
     if (w > i) {
         i = w;
+    }
+
+    // Wrap to 0 if needed
+    if (w == size) {
+        w = 0U;
     }
 
     /* Store the indexes with adequate memory ordering */


### PR DESCRIPTION
Before: ![before](https://user-images.githubusercontent.com/240344/232242300-931cba84-9d7d-448c-a275-bafffb16973f.png)
After: ![after](https://user-images.githubusercontent.com/240344/232242311-49cb5c83-f132-4f3e-bcab-2dff0659db4a.png)
